### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Nimbus consists of several components:
 
 The menubar app is only compatible with OS X 10.9 and up since it is written in [Swift](https://developer.apple.com/swift/). The files are stored in Amazon S3, so you must have an AWS account.
 
-##Screenshots
+## Screenshots
 <table>
   <tr>
     <td><img src="https://raw.githubusercontent.com/ethanal/Nimbus/master/graphics_assets/docs/screenshot_management.png" alt="Screenshot"></td>
@@ -27,7 +27,7 @@ The menubar app is only compatible with OS X 10.9 and up since it is written in 
   </tr>
 </table>
 
-##Features
+## Features
 
 - Share pages that show file previews or redirect to the shortened link
   - Image file previews
@@ -37,7 +37,7 @@ The menubar app is only compatible with OS X 10.9 and up since it is written in 
 - Drag a URL to the menubar icon to create a shortened link and copy it to the clipboard
 - Keep track of view counts for files and shortened URLS
 
-##Setup
+## Setup
 
 To set up the Django app, perform the following steps on your server (assumes [pip](http://pip.readthedocs.org/en/latest/), [virtualenv](http://virtualenv.readthedocs.org/en/latest/), and [MySQL](http://www.mysql.com/) are already installed)
 
@@ -71,7 +71,7 @@ To set up the Django app, perform the following steps on your server (assumes [p
    yes yes | ./manage.py collectstatic
    ```
 
-###Serving Nimbus
+### Serving Nimbus
 
 Make sure you have a domain name configured with the following records:
 
@@ -91,7 +91,7 @@ The recommended setup for serving Nimbus is [Gunicorn](http://gunicorn.org/) man
 * Static file requests (`/static/`) should be aliased to `nimbus/collected_static` in the repository root
 * Supervisor must call the version of gunicorn in your virtualenv
 
-####Example Supervisor Configuration
+#### Example Supervisor Configuration
 
 ```ini
 [program:nimbus]
@@ -105,7 +105,7 @@ autostart = true
 autorestart = true
 ```
 
-####Example Nginx Configuration
+#### Example Nginx Configuration
 ```nginx
 server {
     listen 80;
@@ -145,7 +145,7 @@ server {
 }
 ```
 
-##API Reference
+## API Reference
 API documentation can be found [here](api_docs.md).
 
 ## Contact

--- a/api_docs.md
+++ b/api_docs.md
@@ -1,4 +1,4 @@
-#API Reference
+# API Reference
 
 The Nimbus API uses token authentication, so it is recommended that you secure the `account` and `api` subdomains with HTTPS. The `Authorization` header for requests that require it should have the following form:
 
@@ -10,10 +10,10 @@ The term "media item" refers to a file or a shortened link.
 
 ***
 
-##Obtain Authorization Token
+## Obtain Authorization Token
 Obtain the API authorization token corresponding to a username/password pair.
 
-###Request
+### Request
 - Requires: Authentication
 - HTTP Request Method: `POST`
 - URL: `/api-token-auth`
@@ -21,7 +21,7 @@ Obtain the API authorization token corresponding to a username/password pair.
   - `username`: The username for the user whose token should be returned
   - `password`: The password for the user whose token should be returned
 
-###Response
+### Response
 - Status: 200 OK
 - Body:
 
@@ -31,7 +31,7 @@ Obtain the API authorization token corresponding to a username/password pair.
   }
   ```
 
-###Errors
+### Errors
 
 If the provided credentials are not valid, the following response is returned:
 
@@ -48,7 +48,7 @@ If the provided credentials are not valid, the following response is returned:
 
 ***
 
-##List Media Items
+## List Media Items
 List all media items created by the authorized user.
 
 All media items are serialized the same way. Links and files can be differentiated using the `media_type` attribute.
@@ -63,14 +63,14 @@ Valid media type codes are as follows:
 - `VID`: Video files
 - `ETC`: Other files
 
-###Request
+### Request
 - Requires: Authentication
 - HTTP Request Method: `GET`
 - URL: `/media/list`
 - Optional URL Parameters:
   - `media_type`: The media type code used to filter the list (e.g. `GET /media/list?media_type=IMG` will list all images)
 
-###Response
+### Response
 - Status: 200 OK
 - Body:
 
@@ -103,17 +103,17 @@ Valid media type codes are as follows:
 
 ***
 
-##Show Media Item Details
+## Show Media Item Details
 Show details for a media item.
 
-###Request
+### Request
 - Requires: Authentication
 - HTTP Request Method: `GET`
 - URL: `/media/show`
 - URL Parameters:
   - `url_hash`: The media type code used to filter the list (e.g. `GET /media/list?media_type=IMG` will list all images)
 
-###Response
+### Response
 - Status: 200 OK
 - Body:
 
@@ -133,17 +133,17 @@ Show details for a media item.
 
 ***
 
-##Upload File
+## Upload File
 Create a media item for a file.
 
-###Request
+### Request
 - Requires: Authentication
 - HTTP Request Method: `POST`
 - URL: `/media/add_file`
 - Parameters
   - `file`: The file to upload.
 
-###Response
+### Response
 - Status: 201 Created
 - Body:
 
@@ -161,17 +161,17 @@ Create a media item for a file.
 
 ***
 
-##Add Link
+## Add Link
 Create a media item for a URL.
 
-###Request
+### Request
 - Requires: Authentication
 - HTTP Request Method: `POST`
 - URL: `/media/add_link`
 - Parameters
   - `target_url`: The URL to shorten.
 
-###Response
+### Response
 - Status: 201 Created
 - Body:
 
@@ -186,17 +186,17 @@ Create a media item for a URL.
 
 ***
 
-##Delete Media Items
+## Delete Media Items
 Delete one or more media items.
 
-###Request
+### Request
 - Requires: Authentication
 - HTTP Request Method: `DELETE`
 - URL: `/media/delete`
 - URL Parameters
   - `url_hash`: The URL hash of the media item that should be deleted. This parameter can be repeated to delete multiple items.
 
-###Response
+### Response
 - Status: 204 No Content
 
 ***


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
